### PR TITLE
feat: capture RTCPeerConnection at page load

### DIFF
--- a/iframe-webrtc-test.html
+++ b/iframe-webrtc-test.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <!-- Putting this inline and at the top level
+        so that it gets executed as early as possible.
+        Same in index.html -->
+        <script>globalThis.__capturedWebRTCObj = RTCPeerConnection;</script>
+
         <meta charset="utf-8"/>
         <script src="js/utils.js"></script>
     </head>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <!-- Putting this inline and at the top level
+        so that it gets executed as early as possible.
+        Same in iframe-webrtc-test.html -->
+        <script>globalThis.__capturedWebRTCObj = RTCPeerConnection;</script>
+
         <meta charset="utf-8"/>
         <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -147,6 +147,11 @@ window.addEventListener("load", () => {
 
     document.getElementById("webrtc-output").append(
         createHeader("webrtc-sidechannel"),
+        h(
+            "p",
+            {},
+            "RTCPeerConnection object: " + globalThis.__capturedWebRTCObj,
+        ),
         h("div", {class: "container"},
             resultsHeader,
             ...elements


### PR DESCRIPTION
To more easily test for whether we properly override
the RTCPeerConnection constructor,
or whether we're too late with it.

![image](https://github.com/user-attachments/assets/de3ff2f0-8a74-4605-85c2-d7230e496f32)
