### PR TITLE
added WebRTC Test based on an uninitialized iFrame

### DIFF
--- a/js/webrtc.js
+++ b/js/webrtc.js
@@ -97,7 +97,10 @@ window.addEventListener("load", () => {
     const iframeRegularWindow = iframeRegularEl?.contentWindow;
     /** @type {HTMLIFrameElement} */
     const iframeAllowSameOrigin = document.getElementById('iframe-allow-same-origin');
-    const iframeAllowSameOriginWindow = iframeAllowSameOrigin?.contentWindow;
+    const iframeAllowSameOriginWindow = iframeAllowSameOrigin?.contentWindow?.window;
+    const iframeRegularElDoc = iframeRegularEl.contentDocument
+    iframeRegularElDoc.body.innerHTML += "<iframe id=i></iframe>"
+    const iframeNotInitedWindow = iframeRegularElDoc?.getElementById("i").contentWindow.window;
     const tests = [
         ["RTCPeerConnection", window.RTCPeerConnection],
         ["mozRTCPeerConnection", window.mozRTCPeerConnection],
@@ -108,6 +111,9 @@ window.addEventListener("load", () => {
         ["iframe regular RTCPeerConnection", iframeRegularWindow?.RTCPeerConnection],
         ["iframe regular mozRTCPeerConnection", iframeRegularWindow?.mozRTCPeerConnection],
         ["iframe regular webkitRTCPeerConnection", iframeRegularWindow?.webkitRTCPeerConnection],
+        ["iframe regular uninitialized RTCPeerConnection", iframeNotInitedWindow?.RTCPeerConnection],
+        ["iframe regular uninitialized mozRTCPeerConnection", iframeNotInitedWindow?.mozRTCPeerConnection],
+        ["iframe regular uninitialized webkitRTCPeerConnection", iframeNotInitedWindow?.webkitRTCPeerConnection],
     ];
     const elements = [];
     const testPromises = [];


### PR DESCRIPTION
This test is specifically designed to get the RTCPeerConnection object before the injected script on android is run. The script injected into Android's WebView from Tauri only runs once the page is loaded, compared to other targets where the injected script is run immediately after the iframe is constructed, before yeilding back to the JS on the parent page which created the iframe.

Here's a simplified exploit:

document.body.innerHTML += "<iframe id=i></iframe>" // new window without the WebRTC override
const iframeNotInitedWindow = i.contentWindow.window; // reference to the original peer connection object const newRTC = iframeNotInitedWindow.RTCPeerConnection;

While one might think that it is possible to address this by always triggering the override on any write to innerHTML, there are many, many ways to add an iframe to a document to the point where patching all of the holes is virtually (or possibly completely) impossible. For a
[failed attempt](https://github.com/LavaMoat/snow/issues/158#issuecomment-2094736819) at patching all of the methods possible to insert an iframe without running a script before yielding back to the script which created the iframe, see https://github.com/lavamoat/snow.

This can be mitigated by injecting Fill500 into every document on Android which while not ideal, is a reasonable mitigation for Android specifically.