### PR TITLE
add new webxdc.isAppSender and webxdc.isBroadcast APIs

### DIFF
--- a/js/info.js
+++ b/js/info.js
@@ -5,6 +5,9 @@ window.addEventListener("load", () => {
     container.append(h("div", {}, "webxdc.selfName: ", h("span", {style: "background:#DDD;word-wrap: break-word;"}, webxdc.selfName)))
     container.append(h("div", {}, "webxdc.selfAddr: ", h("span", {style: "background:#DDD;word-wrap: break-word;"}, webxdc.selfAddr)))
 
+    container.append(h("div", {}, "webxdc.isAppSender: ", webxdc.isAppSender));
+    container.append(h("div", {}, "webxdc.isBroadcast: ", webxdc.isBroadcast));
+
     container.append(h("div", {}, "webxdc.sendUpdateInterval: " + webxdc.sendUpdateInterval))
     container.append(h("div", {}, "webxdc.sendUpdateMaxSize: " + webxdc.sendUpdateMaxSize))
 


### PR DESCRIPTION
the new API spec was introduced at https://github.com/webxdc/website/pull/137 and implemented in core at https://github.com/chatmail/core/pull/8138