### PR TITLE
fix: event (e.g. `visibilitychange`) on DC Android

### DIFF
--- a/js/unload.js
+++ b/js/unload.js
@@ -11,15 +11,6 @@ window.addEventListener("load", () => {
     for (const eventName of events) {
         eventNameToNumWebxdcUpdatesFromIt[eventName] = 0;
     }
-    window.anotherWebxdcUpdateListener = function (update) {
-        if (!update.payload?.isEventCounterUpdate) {
-            return;
-        }
-        const { eventName } = update.payload;
-        const newCount =
-            eventNameToNumWebxdcUpdatesFromIt[eventName] += 1;
-        updateWebxdcUpdatesFromListenerElement(eventName, newCount);
-    }
     events.forEach(eventName => {
         container.append(
             h("strong", {}, eventName), " triggered ", h("strong", {id: eventName + "-counter"}, getInt(`docEvent.${eventName}`)), " times",
@@ -46,6 +37,15 @@ window.addEventListener("load", () => {
             }, `${eventName} event counter`);
         });
     });
+    window.addUpdateListener(function (update) {
+        if (!update.payload?.isEventCounterUpdate) {
+            return;
+        }
+        const { eventName } = update.payload;
+        const newCount =
+            eventNameToNumWebxdcUpdatesFromIt[eventName] += 1;
+        updateWebxdcUpdatesFromListenerElement(eventName, newCount);
+    })
 
     function updateWebxdcUpdatesFromListenerElement(eventName, newWebxdcUpdateCount) {
         const el = document.getElementById(eventName + "-counter-sendUpdate");

--- a/js/update-api.js
+++ b/js/update-api.js
@@ -16,7 +16,19 @@ window.addEventListener("load", () => {
          )
     );
 
+    const updates = [];
+    const listeners = [];
+    globalThis.addUpdateListener = function (fn) {
+        for (const update of updates) {
+            fn(update)
+        }
+        listeners.push(fn)
+    }
+
     window.webxdc.setUpdateListener(function (update) {
+        updates.push(update);
+        listeners.forEach(fn => fn(update));
+
         if (!updatesInitialized) {
             previousUpdates++;
         } else {
@@ -26,8 +38,6 @@ window.addEventListener("load", () => {
         }
         document.getElementById("previous-runs").innerHTML = previousUpdates;
         document.getElementById("current-run").innerHTML = currentUpdates;
-
-        window.anotherWebxdcUpdateListener(update);
     }).then(() => {
         updatesInitialized = true;
         window.webxdc.sendUpdate({payload: { "update-api-test": "bar"}}, "test update");


### PR DESCRIPTION
The test would falsely report that "sendUpdate" worked 0 times.
The bug has probably been surfaced by
ada644228eadcd13a20d7ea6c8ae53cad5f157ef
(https://github.com/webxdc/webxdc-test/pull/39),
which reordered the `<script>` tags, which made `setUpdateListener()`
run before `anotherWebxdcUpdateListener` was set.

This commit makes it not matter which order the scripts run in,
by introducing a "wrapper" around `setUpdateListener`.
We also had to move that piece of code in `unload.js`
because otherwise the listener would try to update the elements
before they have been inserted in the document.
